### PR TITLE
Update start_emulators.sh

### DIFF
--- a/scripts/start_emulators.sh
+++ b/scripts/start_emulators.sh
@@ -1,13 +1,27 @@
-var=3
-#IMG_ID=us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
+# Set the image ID to use for the Docker container
+IMG_ID=us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
+
+# Define the initial port numbers
 let port1=29998
 let port2=29999
+
+# Loop through 3 times
 for i in $(seq 1 $var);
 do
-((port1 +=  2))
-((port2 +=  2))
-#docker run -e "ADBKEY=$(cat ~/.android/adbkey)"  --device /dev/kvm --privileged --publish $port2:5556/tcp --publish $port1:5555/tcp ${IMG_ID} &
-docker run -d --rm --privileged -m 8g --memory-reservation=2g -e EMULATOR_ARGS="-no-window -no-boot-anim -netdelay none -no-snapshot -wipe-data -verbose -no-audio -gpu swiftshader_indirect -no-snapshot -read-only -partition-size 512" --device /dev/kvm -p $port1:5554 -p $port2:5555 budtmo/docker-android-x86-8.0:1.8-p1
-sleep 10
-adb connect localhost:$port2
+    # Increment the port numbers for each iteration
+    ((port1 += 2))
+    ((port2 += 2))
+
+    # Start the Docker container
+    docker run -d --rm --privileged -m 8g --memory-reservation=2g \
+    -e EMULATOR_ARGS="-no-window -no-boot-anim -netdelay none -no-snapshot \
+    -wipe-data -verbose -no-audio -gpu swiftshader_indirect -no-snapshot \
+    -read-only -partition-size 512" --device /dev/kvm -p $port1:5554 \
+    -p $port2:5555 budtmo/docker-android-x86-8.0:1.8-p1
+
+    # Wait for the container to start up
+    sleep 10
+
+    # Connect to the Android emulator
+    adb connect localhost:$port2
 done


### PR DESCRIPTION
In this version of the code, the variable var is set to 3, which means that the loop will run 3 times. For each iteration of the loop, the script increments the port numbers by 2, starts a Docker container using the specified image and port numbers, waits 10 seconds for the container to start up, and then connects to the Android emulator using the new port number.